### PR TITLE
10800 minor changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,9 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "edx-adminconsole-web",
-      "version": "1.0.0",
+      "name": "@edfi/admin-console-web",
+      "version": "pre-1.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@chakra-ui/icons": "2.1.1",
         "@chakra-ui/react": "2.8.2",

--- a/src/components/MultiInput.tsx
+++ b/src/components/MultiInput.tsx
@@ -140,7 +140,7 @@ function MultiInput<T extends string | number>({ filterInput, fieldName, label, 
         >
           <AutoCompleteInput
             enterKeyHint='enter'
-            placeholder='Add EdOrg IDs...'
+            placeholder={label}
             size='xs'
             variant="filled"
             onKeyUp={filterInput}

--- a/src/components/common/Instance/PartnerForm.tsx
+++ b/src/components/common/Instance/PartnerForm.tsx
@@ -7,6 +7,7 @@ import {
 } from '@edfi/admin-console-shared-sdk'
 import { EdfiVendor } from '../../../core/Edfi/EdfiVendors'
 import usePartnerForm from '../../../hooks/adminActions/edfi/usePartnerForm'
+import MultiInput from '../../MultiInput'
 import EdFiModalForm from './EdFiModalForm'
 
 interface PartnerFormProps {
@@ -24,6 +25,7 @@ const PartnerForm = ({ initialData, schoolYear, mode, onFinishSave }: PartnerFor
     errors,
     hasTriedSubmit,
     onChangeParnerData,
+    onChangeNamespacePrefixes,
     onSave 
   } = usePartnerForm({ 
     mode,
@@ -69,12 +71,20 @@ const PartnerForm = ({ initialData, schoolYear, mode, onFinishSave }: PartnerFor
           </FormControl>
 
           <FormControl mt='24px'>
-            <CustomFormLabel
-              htmlFor="namespacePrefixes" 
-              text="Namespace Prefixes"
-            />
-
             <Flex
+              flexDir="column"
+              w='full'
+            >
+              {/* error={errors && errors['namespacePrefixes'] && errors['namespacePrefixes'].message} */}
+              <MultiInput
+                // id="namespacePrefixes"
+                label='Add Namespace Prefixes'
+                values={partnerData.namespacePrefixes?.trim()?.split(',') ?? []}
+                onChange={onChangeNamespacePrefixes}
+              />
+            </Flex>
+
+            {/* <Flex
               flexDir='column'
               w='full'
             >
@@ -84,7 +94,7 @@ const PartnerForm = ({ initialData, schoolYear, mode, onFinishSave }: PartnerFor
                 value={partnerData.namespacePrefixes} 
                 onChange={onChangeParnerData}
               />
-            </Flex>
+            </Flex> */}
           </FormControl>
         </Flex>
       </Flex>

--- a/src/components/common/ODS/ODSInstanceTableWrapper.tsx
+++ b/src/components/common/ODS/ODSInstanceTableWrapper.tsx
@@ -92,7 +92,7 @@ const ODSInstanceTableWrapper = ({ tenants, tableMode, pickedInstance, onSelectI
             size='sm'
             onClick={onAddBtnClick}
           >
-            Add ODS Instance
+            Add Instance
           </Button>
         </Flex>
       </Flex> }  

--- a/src/core/Edfi/EdfiVendors.ts
+++ b/src/core/Edfi/EdfiVendors.ts
@@ -1,7 +1,7 @@
 export interface EdfiVendor {
     id?: number
     company?: string 
-    namespacePrefixes?: string 
+    namespacePrefixes?: string
     contactName?: string 
     contactEmailAddress?: string
 }

--- a/src/hooks/adminActions/edfi/usePartnerForm.ts
+++ b/src/hooks/adminActions/edfi/usePartnerForm.ts
@@ -61,9 +61,9 @@ const usePartnerForm = ({ schoolYear, onFinishSave, initialData, mode }: UsePart
       nparnerData.contactEmailAddress = `${e.target.value}@gmail.com`
     }
 
-    if (e.target.id === 'namespacePrefixes') {
-      nparnerData.namespacePrefixes = e.target.value
-    }
+    // if (e.target.id === 'namespacePrefixes') {
+    //   nparnerData.namespacePrefixes = e.target.value.join(',')
+    // }
 
     if (hasTriedSubmit) {
       if (e.target.id === 'partnerName') {
@@ -75,6 +75,19 @@ const usePartnerForm = ({ schoolYear, onFinishSave, initialData, mode }: UsePart
 
     if(partnerData.id) {
       nparnerData.id = partnerData.id
+    }
+
+    setPartnerData(nparnerData)
+  }
+
+  const onChangeNamespacePrefixes = (prefixes: string[]) => {
+    const nparnerData: EdfiVendor = {
+      ...partnerData,
+      namespacePrefixes: prefixes.join(',') 
+    }
+
+    if (hasTriedSubmit) {
+      validateInputChange('namespacePrefixes', nparnerData)
     }
 
     setPartnerData(nparnerData)
@@ -136,6 +149,7 @@ const usePartnerForm = ({ schoolYear, onFinishSave, initialData, mode }: UsePart
     setIsSaving,
     errors,
     hasTriedSubmit,
+    onChangeNamespacePrefixes,
     onChangeParnerData,
     onSave
   }


### PR DESCRIPTION
This pull request includes changes to improve the handling of namespace prefixes in the `PartnerForm` component and updates to placeholder text for better consistency. The most important changes include the introduction of the `MultiInput` component for namespace prefixes, refactoring the `usePartnerForm` hook, and updating placeholder text.

Improvements to handling namespace prefixes:

* [`src/components/common/Instance/PartnerForm.tsx`](diffhunk://#diff-b5a24c223fb50f40bf2d5265c5c4fd2a44dee739661c80ea6e313ad093487e0dL72-R87): Integrated the `MultiInput` component for managing namespace prefixes and updated the form layout accordingly. [[1]](diffhunk://#diff-b5a24c223fb50f40bf2d5265c5c4fd2a44dee739661c80ea6e313ad093487e0dL72-R87) [[2]](diffhunk://#diff-b5a24c223fb50f40bf2d5265c5c4fd2a44dee739661c80ea6e313ad093487e0dL87-R97)
* [`src/hooks/adminActions/edfi/usePartnerForm.ts`](diffhunk://#diff-73940dfbc4283d10a794f1c9c14a7fe22de1ffd7abb774c38f9f0d8cfed0dd1dL64-R66): Added `onChangeNamespacePrefixes` function to handle changes to namespace prefixes and removed the old handling logic. [[1]](diffhunk://#diff-73940dfbc4283d10a794f1c9c14a7fe22de1ffd7abb774c38f9f0d8cfed0dd1dL64-R66) [[2]](diffhunk://#diff-73940dfbc4283d10a794f1c9c14a7fe22de1ffd7abb774c38f9f0d8cfed0dd1dR83-R95) [[3]](diffhunk://#diff-73940dfbc4283d10a794f1c9c14a7fe22de1ffd7abb774c38f9f0d8cfed0dd1dR152)

Updates to placeholder text:

* [`src/components/MultiInput.tsx`](diffhunk://#diff-85a4edd7b9858a41ef4d45ff79d24be6284b3621522728b745151b09bdfdbc72L143-R143): Changed the placeholder text to use the `label` prop.
* [`src/components/common/ODS/ODSInstanceTableWrapper.tsx`](diffhunk://#diff-8ab7ce297bbd48e701a4f15c78bfd1237a7a0f03484a80fef1e54cb9bd777b6fL95-R95): Updated the button text from "Add ODS Instance" to "Add Instance" for consistency.

Work Items:

* https://dev.azure.com/edwire/EW.Educate/_workitems/edit/10801
* https://dev.azure.com/edwire/EW.Educate/_workitems/edit/10802