### PR TITLE
[AC-123]  SBOM docker compose

### DIFF
--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -267,7 +267,7 @@ jobs:
           path: ${{ env.MANIFEST_FILE }}
           sha256: "${{ needs.sbom-create.outputs.sbom-hash-code }}"
 
-      - name: Attach to release
+      - name: Attach SBOM to release
         shell: pwsh
         run: |
           $release = "${{ env.REF }}"
@@ -289,6 +289,47 @@ jobs:
               -Uri "$($url)?name=$($uploadName)" `
               -Headers $gh_headers `
               -InFile $uploadName
+
+  docker-compose-zip:
+    name: Create Docker Compose Zip Asset
+    runs-on: ubuntu-latest
+    needs: azure-publish # Ensure it runs after initial setup/versioning if needed
+    permissions:
+      contents: write # Needed to upload release assets
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Create Docker Compose Zip
+        run: zip -r AdminConsole.DockerCompose.zip ./eng/docker-compose
+
+      - name: Upload Docker Compose Zip to Release
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $release = "${{ env.REF }}"
+          $repo = "${{ github.repository }}"
+          $token = $env:GITHUB_TOKEN
+          $file = "AdminConsole.DockerCompose.zip"
+          $uploadName = "AdminConsole.DockerCompose.zip"
+          $url = "https://api.github.com/repos/$repo/releases/tags/$release"
+          $gh_headers = @{
+              "Accept"        = "application/vnd.github+json"
+              "Authorization" = "Bearer $token"
+          }
+          Write-Host "Fetching release ID for tag $release..."
+          $response = Invoke-RestMethod -Uri $url -Headers $gh_headers
+          $releaseId = $response.id
+          Write-Host "Found release ID: $releaseId"
+          $uploadUrl = "https://uploads.github.com/repos/$repo/releases/$releaseId/assets?name=$($uploadName)"
+          $gh_headers["Content-Type"] = "application/zip"
+          Write-Host "Uploading $file to $uploadUrl..."
+          Invoke-RestMethod -Method POST `
+              -Uri $uploadUrl `
+              -Headers $gh_headers `
+              -InFile $file
+          Write-Host "Upload complete."
 
   provenance-create:
     name: Create Provenance

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -293,7 +293,7 @@ jobs:
   docker-compose-zip:
     name: Create Docker Compose Zip Asset
     runs-on: ubuntu-latest
-    needs: azure-publish # Ensure it runs after initial setup/versioning if needed
+    # needs: azure-publish # Ensure it runs after initial setup/versioning if needed
     permissions:
       contents: write # Needed to upload release assets
     steps:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -7,12 +7,17 @@ name: Publish Dockerfile
 
 on:
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Tag for the Docker image'
+        required: true
+        default: 'pre-alpha'
 
 env:
   DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
   DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
   IMAGE_NAME: ${{ vars.IMAGE_NAME }}
-  IMAGE_TAG: pre-alpha
+  IMAGE_TAG: ${{ inputs.image_tag }}
 permissions: read-all
 
 jobs:

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -18,12 +18,15 @@ COPY . /app
 
 RUN npm run build:prod
 
-COPY config.example.ports.json /app/dist/config.json
+COPY mockdata/* /dist/mockdata/ 
+COPY public/* /dist/ 
+COPY config.example.ports.json /dist/app.config.json
 
 # Remove unnecessary files and folders
-RUN rm -rf .github .npmrc docker eng docs e2e src
+RUN rm -rf .github .npmrc docker eng docs e2e
 
 EXPOSE 8598
 
-# This server is using Vite to serve ths dist folder.
-CMD ["npm", "run", "preview", "--host"]
+# Use node directly
+# https://stackoverflow.com/questions/51191378/what-is-the-point-of-using-pm2-and-docker-together
+CMD ["node", "server.mjs", "--max-http-header-size=16384"]

--- a/eng/docker-compose/compose-adminconsole-published.yml
+++ b/eng/docker-compose/compose-adminconsole-published.yml
@@ -29,3 +29,6 @@ services:
     container_name: ed-fi-adminconsole
     ports:
       - "${ADMIN_CONSOLE_PORT:-8598}:${ADMIN_CONSOLE_PORT:-8598}"
+
+volumes:
+  shared_data:

--- a/eng/docker-compose/compose-adminconsole-published.yml
+++ b/eng/docker-compose/compose-adminconsole-published.yml
@@ -21,7 +21,7 @@ services:
       EG_auth__postLogoutRedirectUri: https://localhost/${ADMIN_CONSOLE_VIRTUAL_NAME:-adminconsole}
       EG_auth__clientId: ${ADMIN_CONSOLE_CLIENT_ID:-ac}
       EG_auth__scope: ${ADMIN_CONSOLE_SCOPE:-edfi_admin_api/full_access}
-      EG_app__basePath: ${ADMIN_CONSOLE_VIRTUAL_NAME:-adminconsole}
+      EG_app__basePath: ${ADMIN_CONSOLE_VIRTUAL_NAME}
     volumes:
       - shared_data:/app
     restart: always

--- a/eng/docker-compose/start.ps1
+++ b/eng/docker-compose/start.ps1
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+[CmdletBinding()]
+param (
+    # Developer flag to ignore the admin console docker image
+    [bool]
+    $ignoreAdminConsole = $false,
+    
+    # Command to specify whether to bring services up or down
+    [ValidateSet("up", "down")]
+    [string]
+    $cmd = "up"
+)
+
+$composeFilePath = Join-Path $PSScriptRoot compose-keycloak-dev.yml
+$composeOds = Join-Path $PSScriptRoot compose-ods-multi-tenant-dev.yml
+$composeLocalAdminApi = Join-Path $PSScriptRoot compose-adminapi-dev.yml
+$composePublishedAdminConsole = Join-Path $PSScriptRoot compose-adminconsole-published.yml
+
+$composeHealthCheckWorker = Join-Path $PSScriptRoot compose-Health-Check-Worker-Process.yml
+$composeInstanceManagementWorker = Join-Path $PSScriptRoot compose-Instance-Management-Worker-Process.yml
+
+$envFilePath = Join-Path $PSScriptRoot .env
+
+$params = @(
+    "--profile", "default",
+    "-f", $composeFilePath,
+    "--env-file", $envFilePath,
+    "-p", "edfi-adminconsole",
+    $cmd,
+    "--remove-orphans"
+)
+
+# Add all files to run
+switch ($ignoreAdminConsole)
+{
+    $false { $params = $params[0..1] + "-f" + $composePublishedAdminConsole + "-f" + $composeLocalAdminApi + "-f" + $composeOds + "-f" + $composeHealthCheckWorker + "-f" + $composeInstanceManagementWorker + $params[2..9] }
+    $true { $params = $params[0..1] + "-f" + $composeLocalAdminApi + "-f" + $composeOds + "-f" + $composeHealthCheckWorker + "-f" + $composeInstanceManagementWorker + $params[2..9] }
+}
+
+Write-Output "Starting EdFi Services..."
+write-output $params
+& docker compose $params
+
+

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev:docker": "set VITE_ENV=local && vite",
     "build": "vite build --mode development",
     "build:prod": "vite build --mode production",
-    "preview": "vite preview",
+    "preview": "vite preview --port 8598",
     "tests": "playwright test",
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --quiet --fix"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev:docker": "set VITE_ENV=local && vite",
     "build": "vite build --mode development",
     "build:prod": "vite build --mode production",
-    "preview": "vite preview --port 8598",
+    "preview": "vite preview --port 8598 --host",
     "tests": "playwright test",
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --quiet --fix"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig(({ mode }) => {
       //   key: fs.readFileSync('./eng/docker-compose/ssl/server.key'),
       //   cert: fs.readFileSync('./eng/docker-compose/ssl/server.crt')
       // },
-      host: !isProd,
+      host: true,
       port: +(process.env.PORT || 8598),
       watch: {
         ignored: [


### PR DESCRIPTION
This adjusts the published Admin Console and corresponding docker file to add Static File Serving support in production. This first iteration adds a set of docker compose yml files for end-users to quickly spin up and configure an admin console environment locally.

This will need to be tested in two parts since there are aspects of the CI/CD pipeline  that have been touched as well as a Docker Hub dependency. Recommeded approaches for each are given:

## Testing Admin Console Artifacts on Fork

This was tested in a Windows 11 environment and requires Docker and Docker Compose to run.

### Step 1: Create release on your fork:
Make sure the PR is checked out and synced with latest changes locally. Create a new tag and release, marking it as pre-release so the correct flow will run. This should create build artifacts including a zip file with the Docker compose yamls.

### Step 2: Create new pre-release and tag:
Check out newly created tagged version and select the Dockerfile in the project root directory. We will need to build this locally to reference since we cannot pull the latest image from docker hub yet.

`docker build --pull --rm -f 'Dockerfile' -t 'edfiadminconsole-web:latest' '.'`

### Step 3: Update the Published configuration:
Download the Docker compose files zip and extract on machine. There should be a directory that contains yamls, shell scripts and example .env files. Update the `compose-adminconsole-published.yml` and replace the Docker hub image reference to point to `image: edfiamdinconsole-web:latest` or which ever name matches the build command from above.

### Step 4: Copy the environment settings:
Copy the env configuration and make it available to the service by running:
`cp ./.env.example ./.env`

### Step 5 Run the services:
Call `./start` to run the docker compose production services. You should be able to navigate to `localhost:8598` successfully once docker compose completes the setup.


## Testing the Docker publish.
Once the artifacts have been validated, the Docker publish workflow can be manually triggered to build and push to Docker Hub. This should publish the image with the most recent production changes and should be configured to work with the included yaml files. Once published, test by resetting the compose-adminconsole-published.yml `image:` property back to the `edfialliance/admin-console-web:${ADMINCONSOLE_TAG:-pre}` where the tag represents the recently published tag.
